### PR TITLE
tch fix_bug in grpo_trainer.py

### DIFF
--- a/src/open_r1/trainer/grpo_trainer.py
+++ b/src/open_r1/trainer/grpo_trainer.py
@@ -415,10 +415,10 @@ class Qwen2VLGRPOTrainer(Trainer):
 
         with torch.inference_mode():
             if self.ref_model is not None:
-                ref_per_token_logps = get_per_token_logps(self.ref_model, prompt_completion_ids)
+                ref_per_token_logps = get_per_token_logps(self.ref_model, prompt_completion_ids, **prompt_inputs) # tch fix_bug
             else:
                 with self.accelerator.unwrap_model(model).disable_adapter():
-                    ref_per_token_logps = get_per_token_logps(model, prompt_completion_ids)
+                    ref_per_token_logps = get_per_token_logps(model, prompt_completion_ids, **prompt_inputs) # tch fix_bug
         ref_per_token_logps = ref_per_token_logps[:, prompt_length - 1 :]
 
         # Compute the KL divergence between the model and the reference model


### PR DESCRIPTION
Hi, thanks for your amazing work!
I've found that the inputs to 'get_per_token_logps' for model and ref_model are different, which might lead to a critical bug. This bug appears in R1-mulitimodal and Open-R1-Video. I've documented my understanding in this blog [Hui-design/R1-Video-fixbug](https://github.com/Hui-design/R1-Video-fixbug). Open-R1-Video has merged my pull request and got performance gains. Could you please review it again to see if my pull request is helpful?